### PR TITLE
test: podinfo UI color change for Flux sanity check

### DIFF
--- a/k8s/infrastructure/base/podinfo/main.yaml
+++ b/k8s/infrastructure/base/podinfo/main.yaml
@@ -47,7 +47,7 @@ spec:
         - --random-error=false
         env:
         - name: PODINFO_UI_COLOR
-          value: "#34577c"
+          value: "#228B22"
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
Changes podinfo UI color from blue (#34577c) to forest green (#228B22) to verify the Flux GitOps deployment pipeline is working correctly.