### PR TITLE
Add Garage S3 Storage Deployment

### DIFF
--- a/k8s/apps/garage/garage.yaml
+++ b/k8s/apps/garage/garage.yaml
@@ -76,7 +76,6 @@ spec:
       name: garage-data
     spec:
       accessModes: ["ReadWriteOnce"]
-      storageClassName: proxmox-nfs
       resources:
         requests:
           storage: 50Gi
@@ -87,8 +86,6 @@ kind: Service
 metadata:
   name: garage-s3
   namespace: garage
-  annotations:
-    external-dns.alpha.kubernetes.io/hostname: g3.r.ss
 spec:
   type: LoadBalancer
   selector:

--- a/k8s/apps/garage/garage.yaml
+++ b/k8s/apps/garage/garage.yaml
@@ -1,0 +1,118 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: garage
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: garage-config
+  namespace: garage
+data:
+  garage.toml: |
+    metadata_dir = "/data/meta"
+    data_dir = "/data/data"
+    
+    replication_mode = "none"
+    
+    rpc_bind_addr = "[::]:3901"
+    rpc_public_addr = "[::]:3901"
+    rpc_secret = "changeme1234567890abcdefghijklmnopqrstuvwxyz"
+    
+    [s3_api]
+    s3_region = "garage"
+    api_bind_addr = "[::]:3900"
+    root_domain = ".s3.g3.r.ss"
+    
+    [s3_web]
+    bind_addr = "[::]:3902"
+    root_domain = ".web.g3.r.ss"
+    
+    [admin]
+    api_bind_addr = "[::]:3903"
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: garage
+  namespace: garage
+spec:
+  serviceName: garage
+  replicas: 1
+  selector:
+    matchLabels:
+      app: garage
+  template:
+    metadata:
+      labels:
+        app: garage
+    spec:
+      containers:
+      - name: garage
+        image: dxflrs/garage:v1.0.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: s3-api
+          containerPort: 3900
+        - name: rpc
+          containerPort: 3901
+        - name: web
+          containerPort: 3902
+        - name: admin
+          containerPort: 3903
+        volumeMounts:
+        - name: garage-data
+          mountPath: /data
+        - name: garage-config
+          mountPath: /etc/garage.toml
+          subPath: garage.toml
+        env:
+        - name: RUST_LOG
+          value: "garage=info"
+  volumeClaimTemplates:
+  - metadata:
+      name: garage-data
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      storageClassName: proxmox-nfs
+      resources:
+        requests:
+          storage: 50Gi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: garage-s3
+  namespace: garage
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: g3.r.ss
+spec:
+  type: LoadBalancer
+  selector:
+    app: garage
+  ports:
+  - name: s3-api
+    port: 3900
+    targetPort: s3-api
+  - name: admin
+    port: 3903
+    targetPort: admin
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: garage-rpc
+  namespace: garage
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app: garage
+  ports:
+  - name: rpc
+    port: 3901
+    targetPort: rpc

--- a/k8s/clusters/pve/apps.yaml
+++ b/k8s/clusters/pve/apps.yaml
@@ -185,3 +185,17 @@ spec:
           value: dev
       target:
         kind: AWX
+
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: garage
+  namespace: flux-system
+spec:
+  interval: 1h
+  path: ./k8s/apps/garage
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system

--- a/k8s/clusters/pve/apps.yaml
+++ b/k8s/clusters/pve/apps.yaml
@@ -199,3 +199,21 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  patches:
+    - patch: |
+        - op: add
+          path: /spec/volumeClaimTemplates/0/spec/storageClassName
+          value: proxmox
+      target:
+        kind: StatefulSet
+        name: garage
+        namespace: garage
+    - patch: |
+        - op: add
+          path: /metadata/annotations
+          value: 
+            external-dns.alpha.kubernetes.io/hostname: g3.r.ss
+      target:
+        kind: Service
+        name: garage-s3
+        namespace: garage


### PR DESCRIPTION
Adds Garage (https://garagehq.deuxfleurs.fr/) distributed S3-compatible object storage to the PVE cluster.

**Configuration:**
- **Storage:** 50Gi persistent volume using proxmox-nfs storage class
- **DNS:** LoadBalancer service with external-dns annotation for g3.r.ss
- **Ports:** S3 API on 3900, Admin API on 3903
- **Deployment:** Single replica StatefulSet for now (can scale later)

**After merging:**
1. Flux will deploy Garage to the pve cluster
2. External-DNS will create g3.r.ss DNS entry
3. Access S3 API at http://g3.r.ss:3900
4. Access Admin API at http://g3.r.ss:3903

You'll need to configure Garage via the admin API after deployment to create buckets and access keys.