### PR TITLE
Fix Garage StatefulSet volume mount

### DIFF
--- a/k8s/apps/garage/garage.yaml
+++ b/k8s/apps/garage/garage.yaml
@@ -71,6 +71,10 @@ spec:
         env:
         - name: RUST_LOG
           value: "garage=info"
+      volumes:
+      - name: garage-config
+        configMap:
+          name: garage-config
   volumeClaimTemplates:
   - metadata:
       name: garage-data


### PR DESCRIPTION
Fixes deployment failure by adding the missing volumes section to reference the garage-config ConfigMap.

**Error fixed:**


The StatefulSet was trying to mount garage-config but the volumes section wasn't defined to reference the ConfigMap.