### PR TITLE
Fix Garage RPC secret key

### DIFF
--- a/k8s/apps/garage/garage.yaml
+++ b/k8s/apps/garage/garage.yaml
@@ -18,7 +18,7 @@ data:
     
     rpc_bind_addr = "[::]:3901"
     rpc_public_addr = "[::]:3901"
-    rpc_secret = "changeme1234567890abcdefghijklmnopqrstuvwxyz"
+    rpc_secret = "36d4bebfa144ffb5b014ec4fca4981bba9a478382cddb23eae578177361e57f7"
     
     [s3_api]
     s3_region = "garage"


### PR DESCRIPTION
Fixes Garage startup crash by using a properly generated 32-byte RPC secret.

**Error fixed:**
```
Error: Invalid RPC secret key: expected 32 bits of entropy, please check the documentation for requirements
```

**Solution:**
- Generated proper 64-character hex string (32 bytes) using `openssl rand -hex 32`
- Replaced placeholder secret that was causing CrashLoopBackOff

The pod was continuously restarting because the RPC secret didn't meet Garage's requirements.