### PR TITLE
fix: use valid DNS-compliant name for Harbor LoadBalancer service

### DIFF
--- a/k8s/apps/harbor/helm-release.yaml
+++ b/k8s/apps/harbor/helm-release.yaml
@@ -21,7 +21,7 @@ spec:
     expose:
       type: loadBalancer
       loadBalancer:
-        name: LoadBalancer
+        name: harbor
         annotations:
           external-dns.alpha.kubernetes.io/hostname: harbor.r.ss
       tls:


### PR DESCRIPTION
## Issue

Harbor HelmRelease was failing because the service name 'LoadBalancer' violates Kubernetes DNS naming requirements (must be lowercase alphanumeric + hyphens).

## Solution

Changed the LoadBalancer service name from 'LoadBalancer' to 'harbor', which is:
- DNS-1035 compliant (lowercase, alphanumeric)
- Follows Kubernetes naming conventions
- Allows the Helm chart to create the service successfully

## Changes

- Updated `k8s/apps/harbor/helm-release.yaml` — changed `loadBalancer.name` from 'LoadBalancer' to 'harbor'

Once merged, Flux will redeploy Harbor with the corrected service name, and the LoadBalancer should come up cleanly.

---
Ready for review!