### PR TITLE
fix: use valuesFrom to inject Harbor admin password from sealed secret

### DIFF
--- a/k8s/apps/harbor/helm-release.yaml
+++ b/k8s/apps/harbor/helm-release.yaml
@@ -17,6 +17,11 @@ spec:
         namespace: harbor
       interval: 5m
   releaseName: harbor
+  valuesFrom:
+    - kind: Secret
+      name: harbor-admin
+      valuesKey: adminPassword
+      targetPath: harborAdminPassword
   values:
     expose:
       type: loadBalancer
@@ -46,7 +51,6 @@ spec:
         trivy:
           storageClass: proxmox
           size: 5Gi
-    harborAdminPassword: "will-be-overridden-by-sealed-secret"
     securityContext:
       runAsNonRoot: true
       runAsUser: 999


### PR DESCRIPTION
## Issue

The admin password from the sealed secret wasn't being injected into the Helm chart. The deployment was using the placeholder text 'will-be-overridden-by-sealed-secret' instead of the actual encrypted password.

## Solution

Added `valuesFrom` to the HelmRelease to read the sealed secret and inject the password value directly into the Helm chart's harborAdminPassword parameter.

## Changes

- Updated `k8s/apps/harbor/helm-release.yaml`
  - Added `valuesFrom` section to read `harbor-admin` secret
  - Maps `adminPassword` key from secret to `harborAdminPassword` chart value
  - Removed hardcoded placeholder value

Once merged, Flux will update Harbor with the correct admin password (x56C3w1c).

---
Ready for review!