### PR TITLE
feat: Deploy OpenBao to cluster

### DIFF
--- a/k8s/apps/openbao/helm-release.yaml
+++ b/k8s/apps/openbao/helm-release.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: openbao
+  namespace: openbao
+spec:
+  interval: 10m
+  timeout: 10m
+  chart:
+    spec:
+      chart: openbao
+      version: "*"
+      sourceRef:
+        kind: HelmRepository
+        name: openbao
+        namespace: openbao
+      interval: 5m
+  releaseName: openbao
+  values:
+    server:
+      replicas: 1
+      image:
+        repository: openbao/openbao
+        tag: null
+      service:
+        type: LoadBalancer
+        port: 8200
+        externalPort: 8200
+      dataStorage:
+        enabled: true
+        size: 10Gi
+        storageClass: proxmox
+      ha:
+        enabled: false
+      ui:
+        enabled: true
+      standalone:
+        enabled: true
+        config: |
+          ui = true
+          listener "tcp" {
+            tls_disable = 1
+            address = "[::]:8200"
+            x_forwarded_for_authorized_addrs = "127.0.0.1"
+          }
+          storage "file" {
+            path = "/openbao/data"
+          }

--- a/k8s/apps/openbao/helm-repo.yaml
+++ b/k8s/apps/openbao/helm-repo.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: openbao
+  namespace: openbao
+spec:
+  interval: 5m
+  url: https://openbao.github.io/openbao-helm

--- a/k8s/apps/openbao/namespace.yaml
+++ b/k8s/apps/openbao/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openbao


### PR DESCRIPTION
Deploys OpenBao (HashiCorp Vault fork) to the isengard cluster with default configuration.

## Changes
- Created openbao namespace
- Added HelmRepository source pointing to openbao/openbao-helm
- Deployed OpenBao HelmRelease with:
  - Single replica in standalone mode
  - File-based storage backend (10Gi PVC)
  - UI enabled on port 8200
  - LoadBalancer service for external access

## Storage
Uses the proxmox storage class for data persistence.

Ready for your review!