### PR TITLE
Update survivor-tracker for season 50 and new Signal relay number

### DIFF
--- a/k8s/apps/signal/relay.yaml
+++ b/k8s/apps/signal/relay.yaml
@@ -12,7 +12,7 @@ data:
 
     [signal]
     api = "api"
-    number = "+15159792049"
+    number = "+14808407117"
     recipient = "+15159792049"
 
 

--- a/k8s/apps/signal/relay.yaml
+++ b/k8s/apps/signal/relay.yaml
@@ -1,46 +1,46 @@
-# ---
-# apiVersion: v1
-# kind: ConfigMap
-# metadata:
-#   name: relay
-#   namespace: signal
-#   labels:
-#     app: relay
-# data:
-#   config.toml: |
-#     logLevel = "debug"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: relay
+  namespace: signal
+  labels:
+    app: relay
+data:
+  config.toml: |
+    logLevel = "debug"
 
-#     [signal]
-#     api = "api"
-#     number = "+15159792049"
-#     recipient = "+15159792049"
+    [signal]
+    api = "api"
+    number = "+15159792049"
+    recipient = "+15159792049"
 
 
-# ---
-# apiVersion: apps/v1
-# kind: Deployment
-# metadata:
-#   name: relay
-#   namespace: signal
-# spec:
-#   replicas: 1
-#   selector:
-#     matchLabels:
-#       app: relay
-#   template:
-#     metadata:
-#       labels:
-#         app: relay
-#     spec:
-#       containers:
-#       - name: relay
-#         image: rssnyder/signal-message-relay:98aa34bce4cb4bca0f416ad29cfa8d958a91e16f
-#         imagePullPolicy: Always
-#         volumeMounts:
-#         - name: config
-#           mountPath: /app/config.toml
-#           subPath: config.toml
-#       volumes:
-#       - name: config
-#         configMap:
-#           name: relay
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: relay
+  namespace: signal
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: relay
+  template:
+    metadata:
+      labels:
+        app: relay
+    spec:
+      containers:
+      - name: relay
+        image: rssnyder/signal-message-relay:98aa34bce4cb4bca0f416ad29cfa8d958a91e16f
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: config
+          mountPath: /app/config.toml
+          subPath: config.toml
+      volumes:
+      - name: config
+        configMap:
+          name: relay

--- a/k8s/apps/survivor-tracker/survivor-tracker.yaml
+++ b/k8s/apps/survivor-tracker/survivor-tracker.yaml
@@ -14,11 +14,11 @@ metadata:
 data:
   config.toml: |
     [survivor]
-    season = "49"
+    season = "50"
 
     [signal]
     api = "api.signal"
-    number = "+15159792049"
+    number = "+14808407117"
     group = "group.ZTVTUzdvNjZSbGFsYTlrR1p0M21KbTQ3eFZNa2ZRWHMzZm1acFlnd1c1Yz0="
 
     [tautulli]


### PR DESCRIPTION
Updates the survivor-tracker deployment config to:
- Update season from 49 to 50
- Update Signal relay number from +15159792049 to +14808407117 (matches new relay deployment)