### PR TITLE
Update survivor-tracker for season 50 and new Signal relay number

### DIFF
--- a/k8s/apps/survivor-tracker/survivor-tracker.yaml
+++ b/k8s/apps/survivor-tracker/survivor-tracker.yaml
@@ -14,11 +14,11 @@ metadata:
 data:
   config.toml: |
     [survivor]
-    season = "49"
+    season = "50"
 
     [signal]
     api = "api.signal"
-    number = "+15159792049"
+    number = "+14808407117"
     group = "group.ZTVTUzdvNjZSbGFsYTlrR1p0M21KbTQ3eFZNa2ZRWHMzZm1acFlnd1c1Yz0="
 
     [tautulli]


### PR DESCRIPTION
Updates the survivor-tracker deployment config to:
- Update season from 49 to 50
- Update Signal relay number from +15159792049 to +14808407117 (matches new relay deployment)