### PR TITLE
feat: Add external-secrets operator deployment

### DIFF
--- a/k8s/apps/survivor-tracker/survivor-tracker.yaml
+++ b/k8s/apps/survivor-tracker/survivor-tracker.yaml
@@ -14,11 +14,11 @@ metadata:
 data:
   config.toml: |
     [survivor]
-    season = "49"
+    season = "50"
 
     [signal]
     api = "api.signal"
-    number = "+15159792049"
+    number = "+14808407117"
     group = "group.ZTVTUzdvNjZSbGFsYTlrR1p0M21KbTQ3eFZNa2ZRWHMzZm1acFlnd1c1Yz0="
 
     [tautulli]

--- a/k8s/clusters/pve/infra.yaml
+++ b/k8s/clusters/pve/infra.yaml
@@ -97,6 +97,20 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: external-secrets
+  namespace: flux-system
+spec:
+  interval: 1h
+  path: ./k8s/infrastructure/pve/external-secrets
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: external-dns
   namespace: flux-system
 spec:

--- a/k8s/infrastructure/pve/external-secrets/helm-release.yaml
+++ b/k8s/infrastructure/pve/external-secrets/helm-release.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-secrets
+  namespace: external-secrets
+spec:
+  interval: 10m
+  timeout: 10m
+  chart:
+    spec:
+      chart: external-secrets
+      version: "*"
+      sourceRef:
+        kind: HelmRepository
+        name: external-secrets
+        namespace: external-secrets
+      interval: 5m
+  releaseName: external-secrets
+  values:
+    installCRDs: true
+    serviceAccount:
+      create: true
+      name: external-secrets
+    secretStores:
+      enabled: false
+    externalSecrets:
+      enabled: false
+    webhook:
+      enabled: true
+      port: 10250

--- a/k8s/infrastructure/pve/external-secrets/helm-release.yaml
+++ b/k8s/infrastructure/pve/external-secrets/helm-release.yaml
@@ -22,10 +22,6 @@ spec:
     serviceAccount:
       create: true
       name: external-secrets
-    secretStores:
-      enabled: false
-    externalSecrets:
-      enabled: false
     webhook:
       enabled: true
       port: 10250

--- a/k8s/infrastructure/pve/external-secrets/helm-repo.yaml
+++ b/k8s/infrastructure/pve/external-secrets/helm-repo.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: external-secrets
+  namespace: external-secrets
+spec:
+  interval: 5m
+  url: https://charts.external-secrets.io

--- a/k8s/infrastructure/pve/external-secrets/namespace.yaml
+++ b/k8s/infrastructure/pve/external-secrets/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-secrets


### PR DESCRIPTION
Deploy the external-secrets operator to the PvE cluster.

## What's included:
- Namespace for external-secrets
- Helm repository configuration
- Helm release deployment with CRD installation and webhook enabled

## Next steps:
- Eventually integrate with HashiCorp Vault backend
- Configure SecretStores and ExternalSecrets as needed

Ready for review!