### PR TITLE
Fix Loki LoadBalancer: use gateway instead of singleBinary

### DIFF
--- a/k8s/clusters/pve/infra.yaml
+++ b/k8s/clusters/pve/infra.yaml
@@ -103,12 +103,13 @@ spec:
     name: flux-system
   patches:
     - patch: |
+        - op: replace
+          path: /spec/values/gateway/service/type
+          value: LoadBalancer
         - op: add
-          path: /spec/values/singleBinary/service
+          path: /spec/values/gateway/service/annotations
           value:
-            type: LoadBalancer
-            annotations:
-              external-dns.alpha.kubernetes.io/hostname: loki.r.ss
+            external-dns.alpha.kubernetes.io/hostname: loki.r.ss
       target:
         kind: HelmRelease
         name: loki

--- a/k8s/infrastructure/base/loki/helm.yaml
+++ b/k8s/infrastructure/base/loki/helm.yaml
@@ -64,7 +64,9 @@ spec:
     write:
       replicas: 0
     gateway:
-      enabled: false
+      enabled: true
+      service:
+        type: ClusterIP
     chunksCache:
       enabled: false
     resultsCache:


### PR DESCRIPTION
singleBinary.service.type doesn't work in Loki chart 6.x (known issue). Enable gateway and expose that as LoadBalancer with external-dns.