### PR TITLE
Deploy whoami app via Flux with Traefik ingress

### DIFF
--- a/k8s/apps/whoami/whoami.yaml
+++ b/k8s/apps/whoami/whoami.yaml
@@ -1,7 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: whoami
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: whoami
+  namespace: whoami
 spec:
   selector:
     matchLabels:
@@ -24,6 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: whoami
+  namespace: whoami
 spec:
   selector:
     app: whoami
@@ -37,6 +45,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: whoami
+  namespace: whoami
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web
 spec:

--- a/k8s/clusters/pve/apps.yaml
+++ b/k8s/clusters/pve/apps.yaml
@@ -225,6 +225,22 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: whoami
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: traefik
+  interval: 1h
+  path: ./k8s/apps/whoami
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: harbor
   namespace: flux-system
 spec:


### PR DESCRIPTION
Adds namespace and Flux Kustomization to deploy whoami test app for testing Traefik ingress.