### PR TITLE
Point *.pve.rileysnyder.dev to Traefik

### DIFF
--- a/playbooks/templates/hurley/Caddyfile.j2
+++ b/playbooks/templates/hurley/Caddyfile.j2
@@ -121,7 +121,7 @@ photos.rileysnyder.dev {
 }
 
 *.pve.rileysnyder.dev {
-    reverse_proxy 192.168.252.254
+    reverse_proxy 192.168.252.253
 
     tls {
         dns digitalocean {{ digitalocean_token }}


### PR DESCRIPTION
Updates Caddy on hurley to route pve subdomain traffic to Traefik (192.168.252.253) instead of ingress-nginx.