### PR TITLE
Add external host to whoami ingress

### DIFF
--- a/k8s/apps/whoami/whoami.yaml
+++ b/k8s/apps/whoami/whoami.yaml
@@ -61,3 +61,13 @@ spec:
             name: whoami
             port:
               number: 80
+  - host: whoami.pve.rileysnyder.dev
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: whoami
+            port:
+              number: 80


### PR DESCRIPTION
Adds whoami.pve.rileysnyder.dev host to Traefik ingress for external access via Caddy.