### PR TITLE
Replace ingress-nginx with Traefik

### DIFF
--- a/k8s/clusters/pve/apps.yaml
+++ b/k8s/clusters/pve/apps.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
-    - name: ingress-nginx
+    - name: traefik
   interval: 1h
   path: ./k8s/infrastructure/base/podinfo
   prune: true
@@ -102,7 +102,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
-    - name: ingress-nginx
+    - name: traefik
     - name: cloudnative-pg
   interval: 1h
   path: ./k8s/apps/keys

--- a/k8s/clusters/pve/infra.yaml
+++ b/k8s/clusters/pve/infra.yaml
@@ -177,31 +177,6 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: ingress-nginx
-  namespace: flux-system
-spec:
-  dependsOn:
-    - name: metallb
-  interval: 1h
-  path: ./k8s/infrastructure/base/ingress-nginx
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-  patches:
-    - patch: |
-        - op: replace
-          path: /spec/values/controller/service/loadBalancerIP
-          value: 192.168.252.254
-      target:
-        kind: HelmRelease
-        name: ingress-nginx
-        namespace: ingress-nginx
-
----
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
   name: traefik
   namespace: flux-system
 spec:
@@ -220,7 +195,7 @@ spec:
           value: LoadBalancer
         - op: add
           path: /spec/values/service/loadBalancerIP
-          value: 192.168.252.253
+          value: 192.168.252.254
         - op: add
           path: /spec/values/service/annotations
           value:

--- a/playbooks/templates/hurley/Caddyfile.j2
+++ b/playbooks/templates/hurley/Caddyfile.j2
@@ -121,7 +121,7 @@ photos.rileysnyder.dev {
 }
 
 *.pve.rileysnyder.dev {
-    reverse_proxy 192.168.252.253
+    reverse_proxy 192.168.252.254
 
     tls {
         dns digitalocean {{ digitalocean_token }}


### PR DESCRIPTION
- Removes ingress-nginx Kustomization
- Sets Traefik to 192.168.252.254
- Updates app dependencies to traefik
- Reverts Caddy to 192.168.252.254

After merge, run: ansible-playbook -i hosts.yml -i secrets.yml playbooks/caddy.yml --limit hurley.r.ss