### PR TITLE
Use MetalLB annotation for Traefik static IP

### DIFF
--- a/k8s/clusters/pve/infra.yaml
+++ b/k8s/clusters/pve/infra.yaml
@@ -194,12 +194,10 @@ spec:
           path: /spec/values/service/type
           value: LoadBalancer
         - op: add
-          path: /spec/values/service/loadBalancerIP
-          value: 192.168.252.254
-        - op: add
           path: /spec/values/service/annotations
           value:
             external-dns.alpha.kubernetes.io/hostname: traefik.r.ss
+            metallb.universe.tf/loadBalancerIPs: 192.168.252.254
       target:
         kind: HelmRelease
         name: traefik


### PR DESCRIPTION
loadBalancerIP in Helm values wasn't being applied to the service. MetalLB annotation works correctly.