### PR TITLE
Replace Frigate NixOS service with Podman container

### DIFF
--- a/playbooks/nix.yml
+++ b/playbooks/nix.yml
@@ -17,6 +17,27 @@
       with_fileglob:
         - "templates/{{ ansible_hostname }}/*.nix"
 
+    - name: frigate directories
+      file:
+        path: "{{ item }}"
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+      loop:
+        - /var/lib/frigate
+        - /var/lib/frigate/media
+      when: ansible_hostname == 'ben'
+
+    - name: frigate config
+      template:
+        src: templates/ben/frigate-config.yml.j2
+        dest: /var/lib/frigate/config.yml
+        owner: root
+        group: root
+        mode: '0644'
+      when: ansible_hostname == 'ben'
+
     - name: test
       shell: nixos-rebuild test
     

--- a/playbooks/templates/ben/configuration.nix
+++ b/playbooks/templates/ben/configuration.nix
@@ -55,6 +55,9 @@
     extraGroups = [
       "networkmanager"
       "wheel"
+      "video"
+      "render"
+      "podman"
     ];
     packages = with pkgs; [
       zsh
@@ -95,57 +98,61 @@
   networking.firewall.allowedTCPPorts = [
     22
     5000
+    8971
+    8554
+    8555
   ];
 
   services.tailscale.enable = true;
   services.tailscale.port = 41641;
   networking.firewall.allowedUDPPorts = [
     41641
+    8555
   ];
 
-  services.frigate = {
-    enable = false;
-    hostname = "localhost";
-
-    settings = {
-      mqtt.enabled = false;
-
-      detectors.ov = {
-        type = "openvino";
-        device = "AUTO";
-        model.path = "/var/lib/frigate/openvino-model/ssdlite_mobilenet_v2.xml";
-      };
-
-      record = {
-        enabled = true;
-        retain = {
-          days = 1;
-          mode = "all";
-        };
-      };
-
-      ffmpeg.hwaccel_args = "preset-vaapi";
-
-      cameras."lab" = {
-        ffmpeg.inputs = [ {
-          path = "rtsp://127.0.0.1:8554/lab";
-          input_args = "preset-rtsp-restream";
-          roles = [ "record" ];
-        } ];
-      };
-    };
+  # Intel GPU hardware acceleration for Frigate
+  hardware.graphics = {
+    enable = true;
+    extraPackages = with pkgs; [
+      intel-media-driver
+      intel-compute-runtime
+      vpl-gpu-rt
+    ];
   };
 
-  services.go2rtc = {
-    enable = false;
-    settings = {
-      streams = {
-        "lab" = [
-          "rtsp://admin:{{ default_password }}@192.168.2.34:554/cam/realmonitor?channel=1&subtype=0"
-        ];
+  # Podman for OCI containers
+  virtualisation.podman = {
+    enable = true;
+    dockerCompat = true;
+  };
+
+  # Frigate NVR container
+  virtualisation.oci-containers = {
+    backend = "podman";
+    containers.frigate = {
+      image = "ghcr.io/blakeblackshear/frigate:stable";
+      autoStart = true;
+      ports = [
+        "5000:5000"
+        "8971:8971"
+        "8554:8554"
+        "8555:8555/tcp"
+        "8555:8555/udp"
+      ];
+      volumes = [
+        "/var/lib/frigate/config.yml:/config/config.yml:ro"
+        "/var/lib/frigate/media:/media/frigate"
+        "/etc/localtime:/etc/localtime:ro"
+      ];
+      environment = {
+        FRIGATE_RTSP_PASSWORD = "{{ default_password }}";
       };
-      rtsp.listen = ":8554";
-      webrtc.listen = ":8555";
+      extraOptions = [
+        "--device=/dev/dri/renderD128:/dev/dri/renderD128"
+        "--shm-size=656m"
+        "--privileged"
+        "--tmpfs=/tmp/cache:size=4000000000"
+      ];
     };
   };
 

--- a/playbooks/templates/ben/frigate-config.yml.j2
+++ b/playbooks/templates/ben/frigate-config.yml.j2
@@ -1,0 +1,264 @@
+mqtt:
+  host: 192.168.252.3
+  port: 1883
+
+go2rtc:
+  streams:
+    back:
+      "ffmpeg:http://192.168.2.31/flv?port=1935&app=bcs&stream=channel0_main.bcs&user=admin&password={{ default_password }}#video=copy#audio=copy#audio=opus"
+    back_sub:
+      "ffmpeg:http://192.168.2.31/flv?port=1935&app=bcs&stream=channel0_ext.bcs&user=admin&password={{ default_password }}"
+    lab:
+      "rtsp://admin:{{ default_password }}@192.168.2.34:554/cam/realmonitor?channel=1&subtype=0"
+    lab_sub:
+      "rtsp://admin:{{ default_password }}@192.168.2.34:554/cam/realmonitor?channel=1&subtype=0"
+    front:
+      "rtsp://admin:{{ default_password }}@192.168.2.30:554/cam/realmonitor?channel=1&subtype=0"
+    front_sub:
+      "rtsp://admin:{{ default_password }}@192.168.2.30:554/cam/realmonitor?channel=1&subtype=0"
+
+detect:
+  enabled: true
+
+face_recognition:
+  enabled: true
+
+lpr:
+  enabled: true
+  enhancement: 0
+  debug_save_plates: true
+  known_plates:
+    altima:
+      - FAV 96
+    camery:
+      - IJN 189
+
+record:
+  enabled: true
+  detections:
+    retain:
+      days: 90
+  continuous:
+    days: 3
+  motion:
+    days: 3
+
+snapshots:
+  enabled: true
+  retain:
+    default: 730
+  quality: 100
+  bounding_box: true
+  crop: false
+
+semantic_search:
+  enabled: true
+  reindex: false
+
+genai:
+  provider: ollama
+  model: llava:13b
+  base_url: http://192.168.2.4:11434
+
+cameras:
+  front:
+    ffmpeg:
+      inputs:
+        - path: rtsp://127.0.0.1:8554/front?video=copy&audio=aac
+          input_args: preset-rtsp-restream
+          roles:
+            - record
+        - path: rtsp://127.0.0.1:8554/front_sub?video=copy
+          input_args: preset-rtsp-restream
+          roles:
+            - detect
+    record:
+      enabled: true
+    detect:
+      enabled: true
+    motion:
+      mask:
+        - 1,0.318,0.474,0.112,0.347,0.117,0.19,0.18,0.182,0.182,0.126,0.053,0.201,0,1,0
+        - 0.704,0.257,0.761,0.268,0.763,0.487,0.713,0.562,0.658,0.569,0.618,0.482,0.627,0.349
+        - 0.226,0.079,0.221,0.3,0.279,0.332,0.339,0.323,0.347,0.238,0.333,0.148,0.283,0.086
+    zones:
+      yard:
+        coordinates:
+          0.358,0.149,0.55,0.198,0.803,0.286,0.554,1,0,1,0,0.74,0.229,0.543,0.184,0.23
+        objects:
+          - person
+          - car
+          - dog
+      driveway:
+        coordinates: 0.927,0.374,0.968,0.664,0.963,0.733,0.73,0.607,0.814,0.322
+        objects:
+          - person
+          - car
+          - dog
+    review:
+      detections:
+        required_zones:
+          - yard
+          - driveway
+      alerts:
+        required_zones:
+          - yard
+          - driveway
+    snapshots:
+      required_zones:
+        - yard
+        - driveway
+    objects:
+      track:
+        - person
+        - car
+        - dog
+
+  back:
+    ffmpeg:
+      inputs:
+        - path: rtsp://127.0.0.1:8554/back?video=copy&audio=aac
+          input_args: preset-rtsp-restream
+          roles:
+            - record
+        - path: rtsp://127.0.0.1:8554/back_sub?video=copy
+          input_args: preset-rtsp-restream
+          roles:
+            - detect
+    review:
+      detections:
+        required_zones:
+          - door
+          - yard
+      alerts:
+        required_zones:
+          - door
+          - yard
+    snapshots:
+      required_zones:
+        - door
+        - yard
+    zones:
+      door:
+        coordinates: 0.674,0.348,0.594,0.344,0.58,0.502,0.659,0.509
+        objects: dog
+        inertia: 3
+        loitering_time: 0
+      yard:
+        coordinates:
+          0,1,1,1,0.978,0.491,0.882,0.487,0.902,0.348,0.503,0.342,0.5,0.461,0.402,0.459,0,0.522
+        objects:
+          - car
+          - person
+          - cat
+    motion:
+      mask:
+        0,0.518,0.404,0.458,0.497,0.458,0.502,0.339,0.902,0.347,0.883,0.486,0.98,0.491,0.983,0.513,1,1,1,0,0,0
+    objects:
+      track:
+        - dog
+        - car
+        - person
+        - cat
+
+  garage:
+    ffmpeg:
+      inputs:
+        - path: "rtsp://admin:{{ default_password }}@192.168.2.32:554/h264Preview_01_main"
+          roles:
+            - record
+            - detect
+    onvif:
+      host: 192.168.2.32
+      port: 8000
+      user: admin
+      password: "{{ default_password }}"
+    objects:
+      track:
+        - person
+    record:
+      enabled: false
+    detect:
+      enabled: false
+
+  lab:
+    ffmpeg:
+      inputs:
+        - path: rtsp://127.0.0.1:8554/lab?video=copy&audio=aac
+          input_args: preset-rtsp-restream
+          roles:
+            - record
+        - path: rtsp://127.0.0.1:8554/lab_sub?video=copy
+          input_args: preset-rtsp-restream
+          roles:
+            - detect
+    record:
+      enabled: false
+    detect:
+      enabled: false
+    objects:
+      track:
+        - person
+    motion:
+      mask:
+        - 0.819,0.056,0.726,0.571,0.882,0.65,1,0.143
+        - 0.34,1,0.891,0.531,1,0.137,1,1
+    zones:
+      couch:
+        coordinates:
+          0.388,0.385,0.378,0.172,0.493,0.148,0.764,0.286,0.712,0.558,0.581,0.561
+        loitering_time: 0
+      desk:
+        coordinates: 0.389,0.395,0.701,0.681,0.346,0.988,0.27,0.432
+        loitering_time: 0
+      door:
+        coordinates: 0.365,0,0.384,0.39,0.268,0.422,0.24,0.023
+        loitering_time: 0
+
+  louie:
+    ffmpeg:
+      inputs:
+        - path: "rtsp://admin:{{ default_password }}@192.168.2.33:554/h264Preview_01_main"
+    record:
+      enabled: false
+    detect:
+      enabled: false
+    onvif:
+      host: 192.168.2.33
+      port: 8000
+      user: admin
+      password: "{{ default_password }}"
+
+objects:
+  filters:
+    person:
+      min_score: 0.7
+      threshold: 0.8
+    dog:
+      min_score: 0.7
+      threshold: 0.8
+    cat:
+      min_score: 0.7
+      threshold: 0.8
+    car:
+      min_score: 0.7
+      threshold: 0.8
+  genai:
+    enabled: true
+    prompt: Describe the {label} in the sequence of images in a concise
+      sentence, be straight and to the point. Do not mention 'sequence of
+      images'. The images are from a security camera, do not mention this. Do
+      not describe the background.
+
+version: 0.17-0
+
+classification:
+  custom:
+    louie:
+      enabled: true
+      name: louie
+      threshold: 0.8
+      object_config:
+        objects:
+          - dog
+        classification_type: sub_label


### PR DESCRIPTION
- Uses Podman (NixOS default) instead of Docker
- Intel GPU hardware acceleration via VA-API (/dev/dri/renderD128)
- Adds frigate-config.yml.j2 template from existing playbook config
- Updates nix.yml playbook to deploy frigate config to /var/lib/frigate/config.yml
- Adds video/render/podman groups for riley user
- Opens firewall ports for RTSP (8554) and WebRTC (8555)

Deploy with:
```
ansible-playbook -i hosts.yml -i secrets.yml playbooks/nix.yml --limit ben
```