### PR TITLE
Add Prometheus node exporter to ben

### DIFF
--- a/playbooks/templates/ben/configuration.nix
+++ b/playbooks/templates/ben/configuration.nix
@@ -95,6 +95,14 @@
 
   services.openssh.enable = true;
 
+  # Prometheus node exporter
+  services.prometheus.exporters.node = {
+    enable = true;
+    port = 9100;
+    enabledCollectors = [ "systemd" ];
+    openFirewall = true;
+  };
+
   networking.firewall.allowedTCPPorts = [
     22
     5000


### PR DESCRIPTION
Enables node exporter on port 9100 with systemd collector.

Scrape target: `ben:9100/metrics`