### PR TITLE
add dns-sd scrape config for prometheus node exporter

### DIFF
--- a/playbooks/templates/targets.yml.j2
+++ b/playbooks/templates/targets.yml.j2
@@ -22,6 +22,17 @@ scrape_configs:
 {% endif %}
 {% endfor %}
 
+- job_name: node_exporter_dns_sd
+  dns_sd_configs:
+    - names:
+        - '_prometheus._tcp.r.ss'
+      type: SRV
+  relabel_configs:
+    - source_labels: [__meta_dns_srv_record_target]
+      regex: '(.+)\.r\.ss\.'
+      target_label: instance
+      replacement: '${1}'
+
 - job_name: remote_clusters
   honor_labels: true
   honor_timestamps: true


### PR DESCRIPTION
## Summary
- Adds a new `node_exporter_dns_sd` job that uses DNS SRV record discovery
- Keeps existing `node_exporter` job with static configs for migration period
- Prometheus will auto-discover VMs via `_prometheus._tcp.r.ss` SRV records

## Terraform module changes required
The `terraform-proxmox-vm` module needs these changes to create SRV records:
- New `node_exporter_enabled` variable (default: true)
- New `node_exporter_port` variable (default: 9100)
- Creates `_prometheus._tcp.r.ss` SRV record pointing to each VM

## Test plan
- [ ] Apply terraform module changes
- [ ] Run `terraform apply` to create SRV records for existing VMs
- [ ] Deploy prometheus config via ansible
- [ ] Verify DNS-SD targets appear in prometheus