### PR TITLE
enable web.enable-lifecycle for prometheus config reloads

### DIFF
--- a/k8s/infrastructure/base/prometheus/helm.yaml
+++ b/k8s/infrastructure/base/prometheus/helm.yaml
@@ -45,5 +45,6 @@ spec:
       defaultFlagsOverride:
         - --storage.tsdb.retention.size=10GB
         - --config.file=/etc/config/prometheus.yml
+        - --web.enable-lifecycle
     alertmanager:
       enabled: false


### PR DESCRIPTION
## Summary
- Adds `--web.enable-lifecycle` flag to prometheus server
- Fixes configmap-reload sidecar errors (403 Forbidden on /-/reload endpoint)

## Root cause
The `defaultFlagsOverride` was missing this flag, causing the reload endpoint to return 403.