### PR TITLE
update proxmox-cloud-controller-manager chart to 0.2.26

### DIFF
--- a/k8s/infrastructure/pve/proxmox/ccm.yaml
+++ b/k8s/infrastructure/pve/proxmox/ccm.yaml
@@ -20,12 +20,14 @@ spec:
   chart:
     spec:
       chart: proxmox-cloud-controller-manager
-      version: "0.2.24"
+      version: "0.2.26"
       sourceRef:
         kind: HelmRepository
         name: sergelogvinov
       interval: 5m
   values:
+    image:
+      tag: v0.13.0
     useDaemonSet: true
     nodeSelector:
       node-role.kubernetes.io/control-plane: "true"


### PR DESCRIPTION
## Summary
- Updates helm chart from 0.2.24 to 0.2.26
- Bug fixes: chart role binding, service account name

Note: App version remains v0.12.3. The v0.13.0 app release exists but the chart hasn't been updated to reference it yet.