### PR TITLE
add master taint toleration for proxmox-ccm

### DIFF
--- a/k8s/infrastructure/pve/proxmox/ccm.yaml
+++ b/k8s/infrastructure/pve/proxmox/ccm.yaml
@@ -31,5 +31,9 @@ spec:
     useDaemonSet: true
     nodeSelector:
       node-role.kubernetes.io/control-plane: "true"
+    tolerations:
+      - key: master
+        operator: Exists
+        effect: NoSchedule
     existingConfigSecret: proxmox-cloud-controller-manager
     logVerbosityLevel: 5


### PR DESCRIPTION
The control-plane node has taint `master=true:NoSchedule` which the CCM DaemonSet wasn't tolerating after the chart update.