### PR TITLE
update loki to 3.6.7 (chart 6.55.0)

### DIFF
--- a/k8s/infrastructure/base/loki/helm.yaml
+++ b/k8s/infrastructure/base/loki/helm.yaml
@@ -25,7 +25,7 @@ spec:
   chart:
     spec:
       chart: loki
-      version: "6.25.1"
+      version: "6.55.0"
       sourceRef:
         kind: HelmRepository
         name: grafana


### PR DESCRIPTION
Updates Loki from chart 6.25.1 to 6.55.0 (app version 3.6.7)